### PR TITLE
Fix missing UPDATE tags in docker files

### DIFF
--- a/official/ubuntu_18_04/docker/core/Dockerfile
+++ b/official/ubuntu_18_04/docker/core/Dockerfile
@@ -191,7 +191,7 @@ RUN apt-get install -y autoconf               `# Used to build SNOPT from source
 # RUN apt-get install -y ffmpeg `# Extract videos from pybullet ` 
 
 
-#[/BASH UPDATE]
+#[BASH UPDATE]
 
 ############################
 # remove unrequired packages

--- a/official/ubuntu_18_04/docker/laas/Dockerfile
+++ b/official/ubuntu_18_04/docker/laas/Dockerfile
@@ -71,3 +71,5 @@ RUN echo "export ROS_PACKAGE_PATH=\"/opt/openrobots/share:\$ROS_PACKAGE_PATH\"" 
 RUN echo "export CMAKE_PREFIX_PATH=\"/opt/openrobots:\$CMAKE_PREFIX_PATH\"" >> /opt/openrobots/setup.bash
 
 RUN chown -R root:root /opt/openrobots
+
+#[/BASH UPDATE]


### PR DESCRIPTION
## Description

Add/modify UPDATE tags in docker files. 
When running the setup_ubuntu script with the update command I was getting errors because of missing/wrong UPDATE tags in two docker files. After this fix everything seems to be working.

## How I Tested

I ran the setup_ubuntu script with update all command.

## I fulfilled the following requirements

- [X ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ X] All new functions/classes are documented and existing documentation is updated according to changes.
- [ X] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
