### PR TITLE
Set DEFAULT_CONFIG based on currently running kernel

### DIFF
--- a/rt-preempt/ubuntu18.04/install_rt_preempt_kernel.sh
+++ b/rt-preempt/ubuntu18.04/install_rt_preempt_kernel.sh
@@ -9,7 +9,7 @@ VERSION_SECOND=10
 VERSION_MINOR=35
 VERSION=$VERSION_MAJOR.$VERSION_SECOND.$VERSION_MINOR
 VERSION_PATCH=$VERSION-rt39
-DEFAULT_CONFIG=/boot/config-5.4.0-73-generic
+DEFAULT_CONFIG=/boot/config-$(uname -r)
 
 if [  ! -f  $DEFAULT_CONFIG ]; then
    echo "Configure file $FILE does not exist. Please use other file."


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Set DEFAULT_CONFIG based on currently running kernel.

To my understanding, DEFAULT_CONFIG should point to the currently running kernel.  This changes over time (as the default kernel of Ubuntu gets updated), so typically the path needs to be customised more or less every time the script is run.  To avoid the need for manual editing, automatically get the version of the current kernel using `uname -r`.


## How I Tested

By running it on a freshly set up Ubuntu 20.04.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
